### PR TITLE
Remove simple view toggle and force responsive design

### DIFF
--- a/client/components/ui/simple-view-toggle.tsx
+++ b/client/components/ui/simple-view-toggle.tsx
@@ -1,5 +1,4 @@
-import { Smartphone, Monitor } from "lucide-react";
-import { useSimpleView } from "@/hooks/use-simple-view";
+import { Smartphone } from "lucide-react";
 import { useRetroMode } from "@/hooks/use-retro-mode";
 import { Button } from "@/components/ui/button";
 import {
@@ -10,7 +9,6 @@ import {
 } from "@/components/ui/tooltip";
 
 export function SimpleViewToggle() {
-  const { isSimpleView, toggleSimpleView } = useSimpleView();
   const { mode } = useRetroMode();
 
   return (
@@ -21,36 +19,17 @@ export function SimpleViewToggle() {
             variant="ghost"
             size="icon"
             onClick={() => {
-              if (mode === "retro") return; // Disable in retro mode
-              console.log(
-                "Simple view toggle clicked! Current state:",
-                isSimpleView,
-              );
-              toggleSimpleView();
-              console.log("After toggle, new state should be:", !isSimpleView);
+              // Simple view toggle is disabled - only mobile version available
+              console.log("Simple view toggle is disabled - mobile version only");
             }}
-            className={`h-10 w-10 rounded-full bg-white/10 backdrop-blur-md border border-white/20 transition-all duration-300 ${
-              mode === "retro"
-                ? "opacity-50 cursor-not-allowed"
-                : "hover:bg-white/20 hover:scale-110 cursor-pointer"
-            } ${isSimpleView ? "bg-cyan-500/20 border-cyan-400/40" : ""}`}
+            className="h-10 w-10 rounded-full bg-white/10 backdrop-blur-md border border-white/20 transition-all duration-300 opacity-50 cursor-not-allowed bg-cyan-500/20 border-cyan-400/40"
           >
-            {isSimpleView ? (
-              <Smartphone className="h-5 w-5 text-cyan-400 transition-all" />
-            ) : (
-              <Monitor className="h-5 w-5 text-white/80 transition-all" />
-            )}
-            <span className="sr-only">Toggle view mode</span>
+            <Smartphone className="h-5 w-5 text-cyan-400 transition-all" />
+            <span className="sr-only">Mobile view only</span>
           </Button>
         </TooltipTrigger>
         <TooltipContent side="bottom">
-          <span>
-            {mode === "retro"
-              ? "View toggle disabled in retro mode"
-              : isSimpleView
-                ? "Switch to desktop view"
-                : "Switch to simple view"}
-          </span>
+          <span>Mobile version only - desktop view removed</span>
         </TooltipContent>
       </Tooltip>
     </TooltipProvider>

--- a/client/components/ui/simple-view-toggle.tsx
+++ b/client/components/ui/simple-view-toggle.tsx
@@ -1,37 +1,5 @@
-import { Smartphone } from "lucide-react";
-import { useRetroMode } from "@/hooks/use-retro-mode";
-import { Button } from "@/components/ui/button";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-
+// Simple view toggle is completely removed - no toggle functionality needed
 export function SimpleViewToggle() {
-  const { mode } = useRetroMode();
-
-  return (
-    <TooltipProvider>
-      <Tooltip>
-        <TooltipTrigger asChild>
-          <Button
-            variant="ghost"
-            size="icon"
-            onClick={() => {
-              // Simple view toggle is disabled - only mobile version available
-              console.log("Simple view toggle is disabled - mobile version only");
-            }}
-            className="h-10 w-10 rounded-full bg-white/10 backdrop-blur-md border border-white/20 transition-all duration-300 opacity-50 cursor-not-allowed bg-cyan-500/20 border-cyan-400/40"
-          >
-            <Smartphone className="h-5 w-5 text-cyan-400 transition-all" />
-            <span className="sr-only">Mobile view only</span>
-          </Button>
-        </TooltipTrigger>
-        <TooltipContent side="bottom">
-          <span>Mobile version only - desktop view removed</span>
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
+  // Return nothing - component is hidden
+  return null;
 }

--- a/client/main.tsx
+++ b/client/main.tsx
@@ -3,6 +3,8 @@ import App from "./App";
 import "./performance-optimization.css";
 import "./mobile-services-animation-fix.css";
 import "./services-smooth-animation.css";
+import "./simple-view-desktop.css";
+import "./simple-view-responsive.css";
 import "./framer-motion-fixes.css";
 
 // Performance monitoring

--- a/client/main.tsx
+++ b/client/main.tsx
@@ -3,8 +3,6 @@ import App from "./App";
 import "./performance-optimization.css";
 import "./mobile-services-animation-fix.css";
 import "./services-smooth-animation.css";
-import "./simple-view-desktop.css";
-import "./simple-view-responsive.css";
 import "./framer-motion-fixes.css";
 
 // Performance monitoring

--- a/client/main.tsx
+++ b/client/main.tsx
@@ -10,11 +10,19 @@ import "./framer-motion-fixes.css";
 // Performance monitoring
 if (typeof window !== "undefined" && process.env.NODE_ENV === "development") {
   // Simple performance logging for development
-  window.addEventListener('load', () => {
-    const perfData = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming;
-    console.log(`Page Load Time: ${perfData.loadEventEnd - perfData.fetchStart}ms`);
-    console.log(`DOM Content Loaded: ${perfData.domContentLoadedEventEnd - perfData.fetchStart}ms`);
-    console.log(`First Paint: ${performance.getEntriesByType('paint').find(p => p.name === 'first-paint')?.startTime}ms`);
+  window.addEventListener("load", () => {
+    const perfData = performance.getEntriesByType(
+      "navigation",
+    )[0] as PerformanceNavigationTiming;
+    console.log(
+      `Page Load Time: ${perfData.loadEventEnd - perfData.fetchStart}ms`,
+    );
+    console.log(
+      `DOM Content Loaded: ${perfData.domContentLoadedEventEnd - perfData.fetchStart}ms`,
+    );
+    console.log(
+      `First Paint: ${performance.getEntriesByType("paint").find((p) => p.name === "first-paint")?.startTime}ms`,
+    );
   });
 }
 

--- a/client/mobile-optimized.css
+++ b/client/mobile-optimized.css
@@ -1,13 +1,35 @@
 /* Mobile-Optimized KOR Digital Styles */
 /* Preserves dark theme while optimizing for mobile performance */
 
-/* Always show mobile version - desktop version removed */
+/* Show appropriate version based on screen size - NO simple view toggle */
 .mobile-version {
-  display: block !important;
+  display: none;
 }
 
 .desktop-version {
-  display: none !important;
+  display: block;
+}
+
+/* Mobile devices (≤768px) - show mobile version only */
+@media (max-width: 768px) {
+  .mobile-version {
+    display: block !important;
+  }
+
+  .desktop-version {
+    display: none !important;
+  }
+}
+
+/* Desktop/tablet devices (>768px) - show desktop version only */
+@media (min-width: 769px) {
+  .mobile-version {
+    display: none !important;
+  }
+
+  .desktop-version {
+    display: block !important;
+  }
 }
 
 /* Core mobile optimizations */

--- a/client/mobile-optimized.css
+++ b/client/mobile-optimized.css
@@ -1,35 +1,13 @@
 /* Mobile-Optimized KOR Digital Styles */
 /* Preserves dark theme while optimizing for mobile performance */
 
-/* Responsive behavior - ensure mobile styles only apply on mobile devices */
+/* Always show mobile version - desktop version removed */
 .mobile-version {
-  display: none;
+  display: block !important;
 }
 
 .desktop-version {
-  display: block;
-}
-
-/* Show mobile version only on mobile devices (≤768px) */
-@media (max-width: 768px) {
-  .mobile-version {
-    display: block !important;
-  }
-
-  .desktop-version {
-    display: none !important;
-  }
-}
-
-/* Ensure desktop version shows on tablets and larger */
-@media (min-width: 769px) {
-  .mobile-version {
-    display: none !important;
-  }
-
-  .desktop-version {
-    display: block !important;
-  }
+  display: none !important;
 }
 
 /* Core mobile optimizations */

--- a/client/pages/Index-desktop.tsx
+++ b/client/pages/Index-desktop.tsx
@@ -867,7 +867,7 @@ export default function Index() {
                 >
                   {`��█╗  █���������� █████������� ██������������██╗
 ������� �����█╔�����█��╔═══���█╗█���������═�������╗
-█████��╝ ██║   ██║███�������█╔���
+█████��╝ ██║   ██║███���������█╔���
 █��╔�����█╗ █���║   ██║█������══█��╗
 █���║  ██��╚█�������█���������╔╝�������║  █��║
 ����������������╝  ╚═╝ ���������������════╝ ╚�����╝  ����═╝`}
@@ -6899,40 +6899,6 @@ const AboutUsSection = React.forwardRef<HTMLDivElement, SectionProps>(
           </svg>
         </div>
 
-        {/* Breathing Orbs */}
-        <div className="absolute inset-0 pointer-events-none overflow-hidden">
-          {[...Array(6)].map((_, i) => (
-            <div
-              key={`breath-orb-${i}`}
-              className="absolute rounded-full"
-              style={{
-                left: `${15 + ((i * 80) % 70)}%`,
-                top: `${20 + ((i * 60) % 60)}%`,
-                width: `${20 + (i % 3) * 15}px`,
-                height: `${20 + (i % 3) * 15}px`,
-                background: `radial-gradient(circle, rgba(${73 + i * 10}, ${146 + i * 5}, 255, 0.3) 0%, transparent 70%)`,
-                animation: `breath ${6 + (i % 4)}s ease-in-out infinite ${i * 0.4}s`,
-                filter: `blur(${2 + (i % 3)}px)`,
-              }}
-            />
-          ))}
-        </div>
-
-        {/* Dynamic Background Waves */}
-        <div className="absolute inset-0 pointer-events-none overflow-hidden">
-          <div
-            className="absolute inset-0 opacity-20"
-            style={{
-              background: `
-                radial-gradient(circle at 20% 80%, rgba(73, 146, 255, 0.3) 0%, transparent 50%),
-                radial-gradient(circle at 80% 20%, rgba(63, 186, 255, 0.2) 0%, transparent 50%),
-                radial-gradient(circle at 40% 40%, rgba(57, 135, 227, 0.1) 0%, transparent 50%)
-              `,
-              animation: "subtle-glow 12s ease-in-out infinite alternate",
-            }}
-          />
-        </div>
-
         {/* Main Content Container */}
         <div className="relative min-h-screen py-4 sm:py-6 lg:py-8 section-container">
           {/* Text Content */}
@@ -11354,7 +11320,7 @@ const PortfolioSection = React.forwardRef<HTMLDivElement, SectionProps>(
                 color: "from-yellow-500 to-orange-500",
               },
               {
-                icon: "���",
+                icon: "��",
                 label: "Featured",
                 x: 88,
                 y: 18,

--- a/client/pages/Index-desktop.tsx
+++ b/client/pages/Index-desktop.tsx
@@ -869,7 +869,7 @@ export default function Index() {
 ������� �����█╔�����█��╔═══���█╗█���������═�������╗
 █████��╝ ██║   ██║███�������█╔���
 █��╔�����█╗ █���║   ██║█������══█��╗
-█���║  ██��╚█�������█������█╔╝�������║  █��║
+█���║  ██��╚█�������█���������╔╝�������║  █��║
 ����������������╝  ╚═╝ ���������������════╝ ╚�����╝  ����═╝`}
                 </pre>
                 <div className="retro-subtitle">RETRO DEVELOPMENT SYSTEMS</div>
@@ -8157,12 +8157,6 @@ const WhatWeDoSection = React.forwardRef<HTMLDivElement, WhatWeDoSectionProps>(
               className={`text-xl sm:text-3xl md:text-4xl lg:text-5xl xl:text-6xl font-bold tracking-tight font-poppins mb-8 ${
                 theme === "light" ? "text-gray-900" : "text-white"
               } warm-glow-text animate-warm-glow-pulse`}
-              style={{
-                filter:
-                  "drop-shadow(0px 4px 12px rgba(16, 185, 129, 0.4)) drop-shadow(0px 2px 8px rgba(59, 130, 246, 0.3)) drop-shadow(0px 1px 4px rgba(236, 72, 153, 0.2))",
-                textShadow:
-                  "0 0 20px rgba(16, 185, 129, 0.5), 0 0 40px rgba(59, 130, 246, 0.3), 0 0 60px rgba(236, 72, 153, 0.2)",
-              }}
               initial={{ opacity: 0, y: 20 }}
               animate={{ opacity: isVisible ? 1 : 0, y: isVisible ? 0 : 20 }}
               transition={{ duration: 0.8, delay: 0.4 }}

--- a/client/pages/Index-desktop.tsx
+++ b/client/pages/Index-desktop.tsx
@@ -6933,9 +6933,6 @@ const AboutUsSection = React.forwardRef<HTMLDivElement, SectionProps>(
           />
         </div>
 
-        {/* Aurora-like Moving Background */}
-        <div className="absolute inset-0 pointer-events-none overflow-hidden"></div>
-
         {/* Main Content Container */}
         <div className="relative min-h-screen py-4 sm:py-6 lg:py-8 section-container">
           {/* Text Content */}
@@ -11357,7 +11354,7 @@ const PortfolioSection = React.forwardRef<HTMLDivElement, SectionProps>(
                 color: "from-yellow-500 to-orange-500",
               },
               {
-                icon: "��",
+                icon: "���",
                 label: "Featured",
                 x: 88,
                 y: 18,

--- a/client/pages/Index-mobile.tsx
+++ b/client/pages/Index-mobile.tsx
@@ -1024,11 +1024,11 @@ export default function Index() {
                     className="warm-glow-text font-semibold"
                     style={{
                       background:
-                        "linear-gradient(135deg, #60a5fa 0%, #34d399 50%, #a78bfa 100%)",
+                        "linear-gradient(90deg, #3B82F6 0%, #06B6D4 100%)",
                       backgroundClip: "text",
                       WebkitBackgroundClip: "text",
                       WebkitTextFillColor: "transparent",
-                      textShadow: "0 0 20px rgba(59, 130, 246, 0.5)",
+                      textShadow: "0 0 15px rgba(59, 130, 246, 0.4)",
                     }}
                   >
                     View Portfolio

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -1,12 +1,21 @@
 import React from "react";
 
-// Import only mobile component
+// Import both components
 import IndexMobile from "./Index-mobile";
+import IndexDesktop from "./Index-desktop";
 
 export default function Index() {
   return (
-    <div className="mobile-version">
-      <IndexMobile />
-    </div>
+    <>
+      {/* Mobile version - visible on mobile devices only (≤768px) */}
+      <div className="mobile-version">
+        <IndexMobile />
+      </div>
+
+      {/* Desktop version - visible on larger screens (>768px) - NO simple view toggle */}
+      <div className="desktop-version">
+        <IndexDesktop />
+      </div>
+    </>
   );
 }

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -1,36 +1,12 @@
-import React, { useEffect } from "react";
-import { useSimpleView } from "@/hooks/use-simple-view";
+import React from "react";
 
-// Import both components directly
+// Import only mobile component
 import IndexMobile from "./Index-mobile";
-import IndexDesktop from "./Index-desktop";
 
 export default function Index() {
-  const { isSimpleView } = useSimpleView();
-
-  useEffect(() => {
-    // Update CSS custom property when simple view changes
-    document.documentElement.style.setProperty(
-      "--simple-view-display",
-      isSimpleView ? "block" : "none",
-    );
-    document.documentElement.style.setProperty(
-      "--desktop-view-display",
-      isSimpleView ? "none" : "block",
-    );
-  }, [isSimpleView]);
-
   return (
-    <>
-      {/* Mobile version - visible on mobile devices (≤768px) OR when simple view is toggled on desktop */}
-      <div className="mobile-version">
-        <IndexMobile />
-      </div>
-
-      {/* Desktop/Tablet version - visible on larger screens (>768px) when simple view is OFF */}
-      <div className="desktop-version">
-        <IndexDesktop />
-      </div>
-    </>
+    <div className="mobile-version">
+      <IndexMobile />
+    </div>
   );
 }

--- a/client/simple-view-desktop.css
+++ b/client/simple-view-desktop.css
@@ -1,58 +1,21 @@
-/* Simple View on Desktop Optimizations */
+/* Mobile Version Optimizations for Larger Screens */
 
-/* When simple view is active on desktop, center the mobile layout */
-@media (min-width: 769px) {
-  .mobile-version {
-    max-width: 500px;
-    margin: 0 auto;
-    box-shadow: 0 0 50px rgba(0, 0, 0, 0.1);
-    border-radius: 20px;
-    overflow: hidden;
-    background: var(--background);
-  }
-  
-  /* Add some padding around the mobile view on desktop */
-  .mobile-version > * {
-    background: inherit;
-  }
-  
-  /* Ensure mobile sections look good in desktop viewport */
-  .mobile-version #services,
-  .mobile-version section {
-    background: inherit;
-  }
-  
-  /* Add subtle mobile frame effect on desktop */
-  .mobile-version::before {
-    content: '';
-    position: fixed;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background: radial-gradient(circle at center, 
-      rgba(59, 130, 246, 0.05) 0%, 
-      rgba(59, 130, 246, 0.02) 50%, 
-      transparent 100%);
-    pointer-events: none;
-    z-index: -1;
-  }
-}
-
-/* Ensure the mobile version scrolls properly when shown on desktop */
+/* Optimize mobile version when viewed on larger screens */
 @media (min-width: 769px) {
   .mobile-version {
     height: 100vh;
     overflow-y: auto;
     scroll-behavior: smooth;
   }
-}
 
-/* Add a subtle indication when in simple view mode */
-@media (min-width: 769px) {
-  body:has(.mobile-version[style*="block"]) {
-    background: linear-gradient(135deg, 
-      var(--background) 0%, 
-      rgba(59, 130, 246, 0.05) 100%);
+  /* Add some padding for better readability on large screens */
+  .mobile-version > * {
+    background: inherit;
+  }
+
+  /* Ensure mobile sections look good in larger viewport */
+  .mobile-version #services,
+  .mobile-version section {
+    background: inherit;
   }
 }

--- a/client/simple-view-responsive.css
+++ b/client/simple-view-responsive.css
@@ -1,35 +1,10 @@
-/* Simple View Toggle Responsive Behavior */
+/* Mobile Only View - Desktop Version Removed */
 
-/* Initialize CSS custom properties */
-:root {
-  --simple-view-display: none;
-  --desktop-view-display: block;
+/* Always show mobile version on all devices */
+.mobile-version {
+  display: block !important;
 }
 
-/* Hide both by default */
-.mobile-version,
 .desktop-version {
-  display: none;
-}
-
-/* Show mobile version ONLY on mobile devices (≤768px) */
-@media (max-width: 768px) {
-  .mobile-version {
-    display: block !important;
-  }
-
-  .desktop-version {
-    display: none !important;
-  }
-}
-
-/* On desktop/tablet (>768px), show version based on simple view toggle */
-@media (min-width: 769px) {
-  .mobile-version {
-    display: var(--simple-view-display) !important;
-  }
-
-  .desktop-version {
-    display: var(--desktop-view-display) !important;
-  }
+  display: none !important;
 }

--- a/client/simple-view-responsive.css
+++ b/client/simple-view-responsive.css
@@ -1,10 +1,32 @@
-/* Mobile Only View - Desktop Version Removed */
+/* Normal Responsive Behavior - NO Simple View Toggle */
 
-/* Always show mobile version on all devices */
+/* Desktop version by default */
 .mobile-version {
-  display: block !important;
+  display: none;
 }
 
 .desktop-version {
-  display: none !important;
+  display: block;
+}
+
+/* Mobile devices (≤768px) - show mobile version */
+@media (max-width: 768px) {
+  .mobile-version {
+    display: block !important;
+  }
+
+  .desktop-version {
+    display: none !important;
+  }
+}
+
+/* Desktop/tablet devices (>768px) - show desktop version */
+@media (min-width: 769px) {
+  .mobile-version {
+    display: none !important;
+  }
+
+  .desktop-version {
+    display: block !important;
+  }
 }


### PR DESCRIPTION
## Purpose

The user requested complete removal of the simple view toggle functionality from the website. They wanted to eliminate the ability to switch between desktop and mobile views manually, ensuring users only see the appropriate version based on their device screen size (responsive design only).

## Code changes

- **Removed SimpleViewToggle component**: Gutted the toggle component to return null, removing all UI controls and functionality
- **Updated Index.tsx**: Removed simple view hook usage and CSS custom property management
- **Modified CSS files**: Updated responsive styles to use standard media queries instead of toggle-based display logic
- **Cleaned up mobile-optimized.css**: Simplified comments and removed toggle-related logic
- **Updated simple-view CSS files**: Converted from toggle-based to pure responsive design
- **Minor formatting**: Fixed code formatting in main.tsx and removed some visual effects from desktop components

The website now uses standard responsive design patterns where mobile version shows on ≤768px screens and desktop version shows on >768px screens, with no manual toggle option.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 16`

🔗 [Edit in Builder.io](https://builder.io/app/projects/1c5f0a15a27646c4bba3bb48d5a2a9b4/quantum-hub)

👀 [Preview Link](https://1c5f0a15a27646c4bba3bb48d5a2a9b4-quantum-hub.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>1c5f0a15a27646c4bba3bb48d5a2a9b4</projectId>-->
<!--<branchName>quantum-hub</branchName>-->